### PR TITLE
fix(entity): fix entities not being able to destroy themselves

### DIFF
--- a/spec/Kiln/Kiln.Entity.spec.js
+++ b/spec/Kiln/Kiln.Entity.spec.js
@@ -20,16 +20,6 @@ describe('Entity', function () {
         testEntity = new TestEntity();
     });
 
-    describe('onCreate', function () {
-
-        it('should call onCreate when the create method is called (usually by the screen)'
-            , function () {
-                testEntity.create();
-                expect(testEntity.hasCalledCreate).toEqual(true);
-            });
-
-    });
-
     describe('onDestroy', function () {
 
         it('should call onDestroy when being destroyed', function () {

--- a/spec/Kiln/integration/ScreenEntity.spec.js
+++ b/spec/Kiln/integration/ScreenEntity.spec.js
@@ -1,0 +1,77 @@
+describe('Integration of Entities within Screens', function () {
+
+    class MenuScreen extends Kiln.Screen {
+        constructor() {
+            super();
+        }
+    }
+
+    class CoolEntity extends Kiln.Entity {
+        constructor() {
+            super();
+        }
+
+    }
+
+    let menuScreen, coolEntity, twoEntity, deleteEntity;
+
+    beforeEach(function () {
+        menuScreen = new MenuScreen();
+        coolEntity = new CoolEntity();
+        twoEntity = new CoolEntity();
+        deleteEntity = new CoolEntity();
+    });
+
+    describe('Adding an Entity to a Screen', function () {
+
+        it('should throw an error when trying to add a non entity', function () {
+            expect(menuScreen.add.bind(null, 'non entity'))
+                .toThrowError('attempted to add non "Kiln.Entity" to "Kiln.Screen"');
+        });
+
+        it('should add the entity to the screen entities with the key being the entity id'
+            , function () {
+
+                //TODO: We have to stub these because the Mouse is not yet decoupled, eventually we shouldn'y have to...
+                spyOn(coolEntity, 'setKiln').and.stub();
+                spyOn(twoEntity, 'setKiln').and.stub();
+
+                menuScreen.add(coolEntity);
+                menuScreen.add(twoEntity);
+
+                expect(menuScreen.entities).not.toEqual({});
+                expect(Object.values(menuScreen.entities).length).toEqual(2);
+                expect(menuScreen.entities[coolEntity.id]).toBe(coolEntity);
+                expect(menuScreen.entities[twoEntity.id]).toBe(twoEntity);
+
+            });
+
+    });
+
+    describe('Deleting an Entity from a Screen', function () {
+
+        beforeEach(function () {
+            spyOn(deleteEntity, 'setKiln').and.stub();
+            menuScreen.add(deleteEntity);
+        });
+
+        it('should throw an error if the id is not passed', function () {
+            expect(menuScreen.delete.bind(null, deleteEntity))
+                .toThrowError('Attempted to delete "Kiln.Entity" from screen, but an invalid id was passed!');
+        });
+
+        it('should remove an entity when the id is correctly passed and throw error', function () {
+            menuScreen.delete(deleteEntity.id);
+            expect(menuScreen.entities).toEqual({});
+        });
+
+        it('should throw an error if you try to delete an entity that is not there', function () {
+            menuScreen.delete(deleteEntity.id);
+            expect(menuScreen.entities).toEqual({});
+            expect(menuScreen.delete.bind(menuScreen, deleteEntity.id))
+                .toThrowError('Tried to delete entity id {' + deleteEntity.id + '} but it does not exist!');
+        });
+
+    });
+
+});

--- a/src/Kiln/packages/KEntity/EntityManager.js
+++ b/src/Kiln/packages/KEntity/EntityManager.js
@@ -1,0 +1,16 @@
+
+let instance;
+
+export default class EntityManager {
+
+    constructor() {
+        if (instance) return instance;
+        instance = this;
+        this.currentId = 1;
+    }
+
+    getNextEntityId() {
+        return this.currentId++;
+    }
+
+}

--- a/src/Kiln/packages/KEntity/KEntity.js
+++ b/src/Kiln/packages/KEntity/KEntity.js
@@ -1,5 +1,7 @@
 import Mouse from "./Input/Mouse/Mouse";
 import ScreenManager from "../KScreen/ScreenManager";
+import EntityManager from "./EntityManager";
+import {noop} from "lodash"
 
 //TODO: This really does not belong here... :/
 function mouseInBounds(x, y, height, width, mouseX, mouseY) {
@@ -9,6 +11,7 @@ function mouseInBounds(x, y, height, width, mouseX, mouseY) {
 export default class KEntity {
     constructor(x, y, height, width) {
         this.kiln = null;
+        this.id = new EntityManager().getNextEntityId();
         this.x = x;
         this.y = y;
         this.height = height;
@@ -17,6 +20,8 @@ export default class KEntity {
         this._intervalList = [];
         this._timeoutList = [];
         this._childEntities = [];
+        this.onDestroy = noop;
+        this.onCreate = noop;
         this.setKiln = function (kiln) {
             this.kiln = kiln;
             this.mouse = new Mouse(kiln);
@@ -66,17 +71,13 @@ export default class KEntity {
             this._timeoutList.forEach((x) => clearTimeout(x));
             window.removeEventListener('keydown', this.handleKeyDown);
             window.removeEventListener('click', this.handleClick);
-            window.removeEventListener('mousemove', this.handleMouseMove)
+            window.removeEventListener('mousemove', this.handleMouseMove);
+            if(this._parent) this._parent.delete(this.id);
         };
-        this.onDestroy = function () {
-            //Overrideable
+        this.setParent = function(parent) {
+            this._parent = parent;
         };
-        this.create = () => {
-            this.onCreate();
-        };
-        this.onCreate = function () {
-            //Overrideable
-        };
+
         let self = this;
 
         this.handleKeyDown = function (e) {

--- a/src/Kiln/packages/KScreen/KScreen.js
+++ b/src/Kiln/packages/KScreen/KScreen.js
@@ -21,20 +21,17 @@ export default class KScreen {
     }
 
     add(entity) {
-
-        if(!(entity instanceof Kiln.Entity)) {
-            throw new Error('attempted to add non "Kiln.Entity" to "Kiln.Screen"');
-        }
-
-        //TODO: See if there is some way to find out if this is called outside the
+        if(!(entity instanceof Kiln.Entity)) throw new Error('attempted to add non "Kiln.Entity" to "Kiln.Screen"');
+        this.entities[entity.id] = entity;
         entity.setKiln(this.kiln);
-        this.entities[this.nonce] = entity;
-        entity.create(this.nonce, this);
+        entity.setParent(this);
+        entity.onCreate();
         this.nonce++;
     }
 
     delete(key) {
-        this.entities[key].destroy();
+        if(!Number.isInteger(key)) throw new Error('Attempted to delete "Kiln.Entity" from screen, but an invalid id was passed!');
+        if(!this.entities[key]) throw new Error('Tried to delete entity id {' + key + '} but it does not exist!');
         delete this.entities[key];
     }
 


### PR DESCRIPTION
the relationship of what identified needed to be moved from the Screen
to the Entity itself in order to make this work

Fixes #4

Note that this also exposed #38, but is not the cause of it. We are reporting this error rather than letting it be swallowed.