### PR TITLE
fix(yarn): change prepublish to publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:dev": "webpack --display-error-details",
     "build:prod": "webpack --config ./webpack.production.config.js",
     "build": "NODE_ENV=production webpack --config ./webpack.production.config.js",
-    "prepublish": "./publish.sh"
+    "publish": "./publish.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
this fixes a bug in yarn that will trigger the
publish script to run when adding packages and
doing various things completely unrelated to
actually publishing anything :(

Fixes #83