### PR TITLE
fix(npm): retain the src folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "files": [
     "/dist",
-    "/docs"
+    "/docs",
+    "/src"
   ],
   "keywords": [
     "game-kiln",


### PR DESCRIPTION
This way webpack can build right from source

Fixes #94