### PR TITLE
fix(mouse): use rect to get mousePos

### DIFF
--- a/spec/Kiln/Kiln.Input.spec.js
+++ b/spec/Kiln/Kiln.Input.spec.js
@@ -1,8 +1,45 @@
-import KInput from "../../src/Kiln/packages/Kinput/KInput";
-import {KEntity} from "../../src";
+import {KInput} from "../../src";
+import {KDraw, KEntity, KScreen} from "../../src";
+import {KGame} from "../../src";
 
 
 describe('Input', function () {
+
+    var mouse, mockKDraw, mockGame;
+
+    beforeAll(function () {
+
+        class TestScreen extends KScreen {
+            constructor() {
+                super();
+                this.onCreate = () => {
+                    this.mustBeDefinedToNotThrowGlobalError = true;
+                }
+            }
+        }
+
+        var canvasElem = document.createElement('CANVAS');
+        canvasElem.id ='test-kiln';
+        var testScreen = new TestScreen();
+
+        mockGame = new KGame('test-kiln', canvasElem, testScreen);
+
+        mockKDraw = new KDraw('test-kiln');
+
+        mouse = new KInput.Mouse('test-kiln');
+
+        spyOn(mockKDraw, 'getCtx').and.returnValue({
+            canvas: {
+                getBoundingClientRect: function () {
+                    return {
+                        left: 0,
+                        top: 0
+                    }
+                }
+            }
+        });
+
+    });
 
     describe('Keyboard Interaction', function () {
 
@@ -150,7 +187,6 @@ describe('Input', function () {
 
     describe('Mouse Interaction', function () {
 
-        let mouse = new KInput.Mouse();
         let down = new MouseEvent('mousedown', {clientX: 100, clientY: 200});
         let up = new MouseEvent('mouseup', {clientX: 100, clientY: 200});
         let move = new MouseEvent('mousemove', {clientX: 100, clientY: 200});
@@ -166,12 +202,12 @@ describe('Input', function () {
         });
 
         it('should allow me to create a new Mouse instance', function () {
-            expect(new KInput.Mouse()).toBeDefined();
+            expect(new KInput.Mouse('test-kiln')).toBeDefined();
         });
 
         it('should always give me the same instance of Mouse as it is a singleton', function () {
             mouse.cached = 'hello';
-            let mouseTwo = new KInput.Mouse();
+            let mouseTwo = new KInput.Mouse('test-kiln');
             expect(mouseTwo.cached).toEqual('hello')
         });
 

--- a/src/Kiln/packages/Kinput/Mouse/Mouse.js
+++ b/src/Kiln/packages/Kinput/Mouse/Mouse.js
@@ -1,9 +1,11 @@
-let instance = null;
+import ScreenManager from "../../KScreen/ScreenManager";
+
+let instanceMap = {};
 
 export default class Mouse {
-    constructor() {
-        if (instance) return instance;
-        instance = this;
+    constructor(kiln) {
+        if(instanceMap[kiln]) return instanceMap[kiln];
+        instanceMap[kiln] = this;
         this._x = 0;
         this._y = 0;
         this._currentId = 0;
@@ -11,26 +13,18 @@ export default class Mouse {
         this._downEvents = new Map();
         this._moveEvents = new Map();
         this._down = false;
-
+        this._rect = new ScreenManager(kiln).getRect();
         window.addEventListener('mouseup', (e) => {
-            this._x = e.clientX;
-            this._y = e.clientY;
             this._down = false;
-            [...this._upEvents.values()].forEach((fn) => fn(e))
+            this._triggerAllEvents('_upEvents', e);
         });
 
         window.addEventListener('mousedown', (e) => {
-            this._x = e.clientX;
-            this._y = e.clientY;
             this._down = true;
-            [...this._downEvents.values()].forEach((fn) => fn(e))
+            this._triggerAllEvents('_downEvents', e);
         });
 
-        window.addEventListener('mousemove', (e) => {
-            this._x = e.clientX;
-            this._y = e.clientY;
-            [...this._moveEvents.values()].forEach((fn) => fn(e))
-        });
+        window.addEventListener('mousemove', (e) => this._triggerAllEvents('_moveEvents', e));
 
     }
 
@@ -42,6 +36,12 @@ export default class Mouse {
         this._downEvents = new Map();
         this._moveEvents = new Map();
         this._down = false;
+    }
+
+    _triggerAllEvents(eventKey, e) {
+        this._x = e.clientX - this._rect.left;
+        this._y = e.clientY - this._rect.top;
+        [...this[eventKey].values()].forEach((fn) => fn(e));
     }
 
     x() {


### PR DESCRIPTION
you will now need to pass the kiln name reference
to KInput.Mouse('name-here') so that the mouse
class can look up the canvas rect and account
for its top and left offset.

BREAKING CHANGE: you will need to change code from

```javascript
let mouse = new KInput.Mouse();
```

to this

```javascript
let mouse = new KInput.Mouse('kiln-name');
```

where kiln-name is the name of your kiln

Fixes #100