### PR TITLE
fix(screen): generate kiln canvas in container

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -5,9 +5,7 @@
     <title>Kiln Example</title>
     <script src="./dist/Game.bundle.js"></script>
 </head>
-<body>
-
-<canvas width="500" height="500" id="game"></canvas>
-
+<body style="margin: 0; width:100vw; height: 100vh;">
+<div id="game" style="width:100vw; height: 100vh;"></div>
 </body>
 </html>

--- a/spec/Kiln/Kiln.Game.spec.js
+++ b/spec/Kiln/Kiln.Game.spec.js
@@ -12,50 +12,49 @@ describe('Game', function () {
             }
         }
 
-        var errorPrefix = '\nKGame accepts [name, canvas, screen] args, \nBUT The below errors occurred';
-        var canvasElem = document.createElement('CANVAS');
-        canvasElem.id ='cool-id';
+        var errorPrefix = '\nKGame accepts [name, container, screen] args, \nBUT The below errors occurred';
+        var containerElem = document.createElement('DIV');
+        containerElem.id ='cool-id';
         var buttonElem = document.createElement('BUTTON');
         var testScreen = new TestScreen();
 
 
-        it('should throw a useful error when an HTML element is not passed', function () {
+        it('should throw a useful error when an HTML container element is not passed', function () {
             expect(KGame.bind(null, 'my-game', null, testScreen))
-                .toThrow(new Error(errorPrefix + '\n["canvas" was not a valid DOM element]'))
+                .toThrow(new Error(errorPrefix + '\n["container" was not a valid DOM element]'))
         });
 
-        it('should throw a useful error when a non canvas element is passed', function () {
+        it('should throw a useful error when a non div container element is passed', function () {
             expect(KGame.bind(null, 'my-game', buttonElem, testScreen))
-                .toThrow(new Error(errorPrefix + '\n["canvas" was not a canvas element]'))
+                .toThrow(new Error(errorPrefix + '\n["container" was not a div element]'))
         });
 
         it('should throw a useful error when a name is not passed', function () {
-            expect(KGame.bind(null, null, canvasElem, testScreen))
+            expect(KGame.bind(null, null, containerElem, testScreen))
                 .toThrow(new Error(errorPrefix + '\n["name" was not a string]'))
         });
 
         it('should throw an error if a starting screen is not defined', function () {
-            expect(KGame.bind(null, 'cool-game', canvasElem, null))
+            expect(KGame.bind(null, 'cool-game', containerElem, null))
                 .toThrow(new Error(errorPrefix + '\n["screen" was not an instance of KScreen]'))
         });
 
         it('should be able to concat all errors together :D', function () {
             expect(KGame.bind(null, null, null, null))
                 .toThrow(new Error(errorPrefix + '\n' +
-                    '["canvas" was not a valid DOM element]\n' +
+                    '["container" was not a valid DOM element]\n' +
                     '["name" was not a string]\n' +
                     '["screen" was not an instance of KScreen]'))
         });
 
         it('should not trow an error if a valid name and canvas element are provided', function () {
-            expect(KGame.bind(null, 'new-game', canvasElem, testScreen)).not.toThrow()
+            expect(KGame.bind(null, 'new-game', containerElem, testScreen)).not.toThrow()
         });
 
         describe('Getter functionality', function () {
 
-            it('should return a useful error when trying to lookup a non-existing game', function () {
-                expect(KGame.bind(null, 'non-existing-game'))
-                    .toThrow(new Error("No Kiln found for \"non-existing-game\""));
+            it('should return null when trying to lookup a non-existing game', function () {
+                expect(KGame('non-existing-game')).toEqual(null)
             });
 
             describe('When a Kiln does exist', function () {
@@ -63,7 +62,7 @@ describe('Game', function () {
                 var instance;
 
                 beforeAll(function () {
-                    KGame('real-game', canvasElem, testScreen);
+                    KGame('real-game', containerElem, testScreen);
                     instance = KGame('real-game');
                 });
 
@@ -71,8 +70,12 @@ describe('Game', function () {
                     expect(instance.name).toEqual('real-game');
                 });
 
-                it('should have an element reference', function () {
-                    expect(instance._element.id).toEqual('cool-id');
+                it('should have a container element reference', function () {
+                    expect(instance._container.id).toEqual('cool-id');
+                });
+
+                it('should have the canvas element to reference', function () {
+                    expect(instance._canvas.tagName).toEqual('CANVAS')
                 });
 
                 it('should have the correct gameLoop reference', function () {

--- a/spec/Kiln/Kiln.Input.spec.js
+++ b/spec/Kiln/Kiln.Input.spec.js
@@ -18,11 +18,11 @@ describe('Input', function () {
             }
         }
 
-        var canvasElem = document.createElement('CANVAS');
-        canvasElem.id ='test-kiln';
+        var containerElem = document.createElement('DIV');
+        containerElem.id ='test-kiln';
         var testScreen = new TestScreen();
 
-        mockGame = new KGame('test-kiln', canvasElem, testScreen);
+        mockGame = new KGame('test-kiln', containerElem, testScreen);
 
         mockKDraw = new KDraw('test-kiln');
 

--- a/src/Kiln/packages/KGame/KGame.js
+++ b/src/Kiln/packages/KGame/KGame.js
@@ -6,31 +6,26 @@ var kGameStore = {};
 
 export default function KGame(kilnName, bindElement, initialScreen) {
 
-    if (arguments.length === 1) {
-        if (!kGameStore[kilnName]) throw new Error('No Kiln found for "' + kilnName + '"');
-        return kGameStore[kilnName]
-    }
+    if (arguments.length === 1) return kGameStore[kilnName] || null;
 
-    var errorPrefix = '\nKGame accepts [name, canvas, screen] args, \nBUT The below errors occurred';
+    var errorPrefix = '\nKGame accepts [name, container, screen] args, \nBUT The below errors occurred';
     var errors = [];
 
     function check(predicate, errorMessage) {
         if (predicate) errors.push(errorMessage)
     }
 
-    check(!(bindElement instanceof Element), '["canvas" was not a valid DOM element]');
-    check(bindElement && bindElement.nodeName !== 'CANVAS', '["canvas" was not a canvas element]');
+    check(!(bindElement instanceof Element), '["container" was not a valid DOM element]');
+    check(bindElement && bindElement.nodeName !== 'DIV', '["container" was not a div element]');
     check(typeof kilnName !== "string", '["name" was not a string]');
     check(!initialScreen || !(initialScreen instanceof KScreen), '["screen" was not an instance of KScreen]');
 
     if (errors.length > 0) throw new Error(errors.reduce((col, e) => col + '\n' + e, errorPrefix));
 
-    let gameLoop = new LoopManager(kilnName, bindElement, initialScreen);
-
-    if (gameLoop.initialized) {
+    if (KGame(kilnName)) {
         throw new Error('A game with the name ' + kilnName + ' has already been initialized!')
     } else {
-        kGameStore[kilnName] = new KGameInstance(kilnName, bindElement, initialScreen, gameLoop);
+        kGameStore[kilnName] = new KGameInstance(kilnName, bindElement, initialScreen);
     }
 
 }

--- a/src/Kiln/packages/KGame/KGameInstance.js
+++ b/src/Kiln/packages/KGame/KGameInstance.js
@@ -1,11 +1,14 @@
 import ScreenManager from "../KScreen/ScreenManager";
+import LoopManager from "./Loop/LoopManager";
 
 export default class KGameInstance {
 
-    constructor(kilnName, bindElement, initialScreen, gameLoop) {
+    constructor(kilnName, bindElement, initialScreen) {
         this.name = kilnName;
-        this._element = bindElement;
-        this._loopManager = gameLoop;
+        this._container = bindElement;
+        this._canvas = document.createElement('canvas');
+        this._container.appendChild(this._canvas);
+        this._loopManager = new LoopManager(this.name, this._canvas, initialScreen);
         this._screenManager = new ScreenManager(this.name);
         this._loopManager.init();
     }

--- a/src/Kiln/packages/KScreen/ScreenManager.js
+++ b/src/Kiln/packages/KScreen/ScreenManager.js
@@ -5,29 +5,18 @@ let instance = {};
 export default class ScreenManager {
 
     constructor(kiln, elem, initialScreen) {
-
         if (instance[kiln]) return instance[kiln];
         instance[kiln] = this;
-
         this.initialized = false;
         this.kiln = kiln;
         this.canvas = elem;
         this.ctx = elem.getContext('2d');
-        this.canvas.width = window.innerWidth;
-        this.canvas.height = window.innerHeight;
         this.set(initialScreen);
-
         Object.defineProperty(this, 'height', {get: () => this.canvas.height});
         Object.defineProperty(this, 'width', {get: () => this.canvas.width});
-
-        window.addEventListener('resize', () => {
-            this.canvas.width = window.innerWidth;
-            this.canvas.height = window.innerHeight;
-            this.resize();
-        });
-
+        window.addEventListener('resize', this.resize.bind(this));
         window.addEventListener('contextmenu', () => false);
-
+        this.resize();
     }
 
     getCtx() {
@@ -43,6 +32,8 @@ export default class ScreenManager {
     }
 
     resize() {
+        this.canvas.width = this.canvas.parentNode.offsetWidth;
+        this.canvas.height = this.canvas.parentNode.offsetHeight;
         each(this.activeScreen.entities, (e) => e.onResize());
     }
 


### PR DESCRIPTION
BREAKING CHANGE: you will now need to specify a
div element rather than a canvas element when
initializing KGames. The passed div will be filled
with a canvas element respecting the height and
width of the container class.

this allows for us to appropriately resize canvas
and properly track mouse position regardless of
canvas size. This is good because we can have both
fixed and variable width games now.

Fixes #103 #12