### PR TITLE
fix(KEntity): properly propagate kiln name

### DIFF
--- a/spec/Kiln/Kiln.Entity.spec.js
+++ b/spec/Kiln/Kiln.Entity.spec.js
@@ -17,6 +17,13 @@ describe('Entity', function () {
 
     }
 
+    class TestChildEntity extends KEntity {
+        constructor() {
+            super();
+            this.name = 'Cody';
+        }
+    }
+
     beforeEach(function () {
         testEntity = new TestEntity();
     });
@@ -92,6 +99,27 @@ describe('Entity', function () {
             expect(testEntity.intervalBoops).toEqual(1)
         });
 
-    })
+    });
+
+    describe('add', function () {
+
+        var child;
+
+        beforeEach(function () {
+            child = new TestChildEntity();
+            spyOn(testEntity, '_addToScreenManager').and.stub();
+            testEntity.kiln = 'cody';
+            testEntity.add(child);
+        });
+
+        it('should set the kiln of the child to that of the parent', function () {
+            expect(child.kiln).toEqual('cody')
+        });
+
+        it('should set the _parent to that of the parent', function () {
+            expect(child._parent).toEqual(testEntity);
+        });
+
+    });
 
 });

--- a/src/Kiln/packages/KEntity/KEntity.js
+++ b/src/Kiln/packages/KEntity/KEntity.js
@@ -28,10 +28,9 @@ export default class KEntity {
             this._timeoutList.push(setTimeout(fn.bind(this), timeout))
         };
         this.add = function (child) {
-            //TODO: Children are linked before the root is added to the screen :(
-            //TODO: I want to add one way binding to child entities :)
-            this._screenManager = this._screenManager || new ScreenManager(this.kiln);
-            this._screenManager.activeScreen.add(child);
+            child.setKiln(this.kiln);
+            child.setParent(this);
+            this._addToScreenManager(child);
             this._childEntities.push(child);
         };
         this.destroy = function () {
@@ -44,6 +43,10 @@ export default class KEntity {
         this.setParent = function(parent) {
             this._parent = parent;
         };
+        this._addToScreenManager = function (child) {
+            this._screenManager = this._screenManager || new ScreenManager(this.kiln);
+            this._screenManager.activeScreen.add(child);
+        }
 
     }
 


### PR DESCRIPTION
now children added to parents will have their kiln
set in the same way they would if they were added
to a scren.

Fixes #115